### PR TITLE
Add getPlayerByUID method to ScriptEnvironment class and fix instance_functions.cpp

### DIFF
--- a/src/lua/functions/instances/instance_functions.cpp
+++ b/src/lua/functions/instances/instance_functions.cpp
@@ -31,7 +31,7 @@ void InstanceFunctions::init(lua_State* L) {
 
 int InstanceFunctions::luaCreatePlayerInstance(lua_State* L) {
 	// createPlayerInstance(player, mapName, entryPosition, exitPosition, isPartyInstance)
-	const auto &player = Lua::getScriptEnv()->getPlayerByUID(Lua::getNumber<uint32_t>(L, 1));
+	const auto &player = Lua::getPlayer(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -59,7 +59,7 @@ int InstanceFunctions::luaCreatePlayerInstance(lua_State* L) {
 
 int InstanceFunctions::luaTeleportToPlayerInstance(lua_State* L) {
 	// teleportToPlayerInstance(player, instanceId)
-	const auto &player = Lua::getScriptEnv()->getPlayerByUID(Lua::getNumber<uint32_t>(L, 1));
+	const auto &player = Lua::getPlayer(L, 1);
 	if (!player) {
 		lua_pushboolean(L, false);
 		return 1;
@@ -73,7 +73,7 @@ int InstanceFunctions::luaTeleportToPlayerInstance(lua_State* L) {
 
 int InstanceFunctions::luaTeleportFromPlayerInstance(lua_State* L) {
 	// teleportFromPlayerInstance(player)
-	const auto &player = Lua::getScriptEnv()->getPlayerByUID(Lua::getNumber<uint32_t>(L, 1));
+	const auto &player = Lua::getPlayer(L, 1);
 	if (!player) {
 		lua_pushboolean(L, false);
 		return 1;
@@ -86,7 +86,7 @@ int InstanceFunctions::luaTeleportFromPlayerInstance(lua_State* L) {
 
 int InstanceFunctions::luaIsPlayerInInstance(lua_State* L) {
 	// isPlayerInInstance(player)
-	const auto &player = Lua::getScriptEnv()->getPlayerByUID(Lua::getNumber<uint32_t>(L, 1));
+	const auto &player = Lua::getPlayer(L, 1);
 	if (!player) {
 		lua_pushboolean(L, false);
 		return 1;
@@ -99,7 +99,7 @@ int InstanceFunctions::luaIsPlayerInInstance(lua_State* L) {
 
 int InstanceFunctions::luaGetPlayerInstanceId(lua_State* L) {
 	// getPlayerInstanceId(player)
-	const auto &player = Lua::getScriptEnv()->getPlayerByUID(Lua::getNumber<uint32_t>(L, 1));
+	const auto &player = Lua::getPlayer(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -133,13 +133,13 @@ int InstanceFunctions::luaCleanupPlayerInstances(lua_State* L) {
 
 int InstanceFunctions::luaTeleportToPartyMemberInstance(lua_State* L) {
 	// teleportToPartyMemberInstance(player, partyMember)
-	const auto &player = Lua::getScriptEnv()->getPlayerByUID(Lua::getNumber<uint32_t>(L, 1));
+	const auto &player = Lua::getPlayer(L, 1);
 	if (!player) {
 		lua_pushboolean(L, false);
 		return 1;
 	}
 	
-	const auto &partyMember = Lua::getScriptEnv()->getPlayerByUID(Lua::getNumber<uint32_t>(L, 2));
+	const auto &partyMember = Lua::getPlayer(L, 2);
 	if (!partyMember) {
 		lua_pushboolean(L, false);
 		return 1;

--- a/src/lua/scripts/script_environment.cpp
+++ b/src/lua/scripts/script_environment.cpp
@@ -129,6 +129,14 @@ std::shared_ptr<Container> ScriptEnvironment::getContainerByUID(uint32_t uid) {
 	return item->getContainer();
 }
 
+std::shared_ptr<Player> ScriptEnvironment::getPlayerByUID(uint32_t uid) {
+	const auto &thing = getThingByUID(uid);
+	if (!thing) {
+		return nullptr;
+	}
+	return thing->getPlayer();
+}
+
 void ScriptEnvironment::removeItemByUID(uint32_t uid) {
 	if (uid <= std::numeric_limits<uint16_t>::max()) {
 		g_game().removeUniqueItem(static_cast<uint16_t>(uid));

--- a/src/lua/scripts/script_environment.hpp
+++ b/src/lua/scripts/script_environment.hpp
@@ -71,6 +71,7 @@ public:
 	std::shared_ptr<Thing> getThingByUID(uint32_t uid);
 	std::shared_ptr<Item> getItemByUID(uint32_t uid);
 	std::shared_ptr<Container> getContainerByUID(uint32_t uid);
+	std::shared_ptr<Player> getPlayerByUID(uint32_t uid);
 	void removeItemByUID(uint32_t uid);
 
 private:


### PR DESCRIPTION
This PR adds the missing `getPlayerByUID` method to the `ScriptEnvironment` class and fixes the usage in `instance_functions.cpp` where this method was being called but was not defined.

The implementation follows the same pattern as the existing `getItemByUID` and `getContainerByUID` methods, retrieving the Thing object by UID and then calling the `getPlayer()` method on it.