### PR TITLE
Fix: Add Player class declaration in script_environment.hpp

### DIFF
--- a/src/lua/scripts/script_environment.hpp
+++ b/src/lua/scripts/script_environment.hpp
@@ -17,6 +17,7 @@ class Creature;
 class Item;
 class Container;
 class Npc;
+class Player;
 
 class LuaScriptInterface;
 class Cylinder;


### PR DESCRIPTION
Este PR adiciona a declaração da classe Player no arquivo script_environment.hpp para corrigir erros de compilação relacionados ao método getPlayerByUID.