### PR TITLE
Fix: Add Party class include in instance_manager.cpp

### DIFF
--- a/src/game/instances/instance_manager.cpp
+++ b/src/game/instances/instance_manager.cpp
@@ -11,6 +11,7 @@
 #include "game/game.hpp"
 #include "map/map.hpp"
 #include "utils/tools.hpp"
+#include "creatures/players/grouping/party.hpp"
 
 uint32_t InstanceManager::createInstance(const std::shared_ptr<Player> &player, const std::string &mapName, const Position &entryPosition, const Position &exitPosition, bool isPartyInstance) {
 	if (!player) {


### PR DESCRIPTION
Este PR adiciona o include da classe Party no arquivo instance_manager.cpp para corrigir erros de compilação relacionados ao uso de métodos da classe Party.